### PR TITLE
Simplify api

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,7 +9,6 @@ OXRS_SENSORS	KEYWORD1
 #######################################
 
 begin       KEYWORD2
-oled		KEYWORD2
 tele		KEYWORD2
 conf		KEYWORD2
 cmnd		KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=
 category=I2CSensors
 url=https://github.com/austinscreations/OXRS-AC-I2CSensors-ESP-LIB
 architectures=*
-depends=ArduinoJson,Wire,Adafruit_MCP9808,Adafruit_SSD1306,RTClib,BH1750,Adafruit_SHT4x
+depends=ArduinoJson,Wire,Adafruit_MCP9808,BH1750,Adafruit_SHT4x

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-I2CSensor-ESP-LIB
-version=0.5.1
+version=1.0.0
 author=Austins Creations
 maintainer=Austins Creations
 sentence=ESP I2C Sensor library for Open eXtensible Rack System firmware

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=
 category=I2CSensors
 url=https://github.com/austinscreations/OXRS-AC-I2CSensors-ESP-LIB
 architectures=*
-depends=OXRS_MQTT,ArduinoJson,Wire,Adafruit_MCP9808,Adafruit_SSD1306,RTClib,BH1750,Adafruit_SHT4x
+depends=ArduinoJson,Wire,Adafruit_MCP9808,Adafruit_SSD1306,RTClib,BH1750,Adafruit_SHT4x

--- a/src/OXRS_SENSORS.cpp
+++ b/src/OXRS_SENSORS.cpp
@@ -66,8 +66,8 @@ bool OXRS_SENSORS::scanI2CAddress(byte address, const char * name)
 void OXRS_SENSORS::setConfigSchema(JsonVariant json)
 {
   JsonObject _updateSeconds = json.createNestedObject("sensorUpdateSeconds");
-  _updateSeconds["title"] = "Sensor Publish Interval (seconds)";
-  _updateSeconds["description"] = "How often to publish values from the connected I2C sensors (defaults to 60 seconds, setting to 0 disables sensor reports). Must be a number between 0 and 86400 (i.e. 1 day).";
+  _updateSeconds["title"] = "Sensor Update Interval (seconds)";
+  _updateSeconds["description"] = "How often to read and report values from the connected I2C sensors (defaults to 60 seconds, setting to 0 disables sensor reports). Must be a number between 0 and 86400 (i.e. 1 day).";
   _updateSeconds["type"] = "integer";
   _updateSeconds["minimum"] = 0;
   _updateSeconds["maximum"] = 86400;
@@ -75,8 +75,9 @@ void OXRS_SENSORS::setConfigSchema(JsonVariant json)
   if (_mcp9808Found || _sht40Found)
   {
     JsonObject _tempUnits = json.createNestedObject("sensorTempUnits");
+    _tempUnits["title"] = "Sensor Temperature Units";
+    _tempUnits["description"] = "Publish temperature reports in celcius (default) or farenhite";
     _tempUnits["type"] = "string";
-    _tempUnits["description"] = "Temperature reports in celcius (default) or farenhite";
     JsonArray _tempUnitsEnum = _tempUnits.createNestedArray("enum");
     _tempUnitsEnum.add("c");
     _tempUnitsEnum.add("f");
@@ -98,13 +99,13 @@ void OXRS_SENSORS::conf(JsonVariant json)
     _updateMs = json["sensorUpdateSeconds"].as<uint32_t>() * 1000L;
   }
 
-  if (json.containsKey("sensorTempMode"))
+  if (json.containsKey("sensorTempUnits"))
   {
-    if (strcmp(json["sensorTempMode"], "c") == 0)
+    if (strcmp(json["sensorTempUnits"], "c") == 0)
     {
       _tempUnits = TEMP_C;
     }
-    else if (strcmp(json["sensorTempMode"], "f") == 0)
+    else if (strcmp(json["sensorTempUnits"], "f") == 0)
     {
       _tempUnits = TEMP_F;
     }

--- a/src/OXRS_SENSORS.cpp
+++ b/src/OXRS_SENSORS.cpp
@@ -88,7 +88,7 @@ bool OXRS_SENSORS::scanI2CAddress(byte address, const char * name)
 
   // Check if there is anything responding on this address
   Wire.beginTransmission(address);
-  return Wire.endTransmission() == 0;
+  if (Wire.endTransmission() == 0)
   {
     Serial.println(name);
     return true;

--- a/src/OXRS_SENSORS.cpp
+++ b/src/OXRS_SENSORS.cpp
@@ -18,12 +18,12 @@ void OXRS_SENSORS::begin()
 {
   Serial.println(F("[sens] scanning for I2C devices..."));
 
-  if (scanI2CAddress(BH1750_I2C_ADDRESS, "BH1750"))
+  if (scanI2CAddress(BH1750_I2C_ADDRESS))
   {
     _bh1750Found = _bh1750.begin(BH1750::CONTINUOUS_HIGH_RES_MODE);
   }
 
-  if (scanI2CAddress(SHT40_I2C_ADDRESS, "SHT40"))
+  if (scanI2CAddress(SHT40_I2C_ADDRESS))
   {
     _sht40Found = _sht40.begin();
     if (_sht40Found)
@@ -33,7 +33,7 @@ void OXRS_SENSORS::begin()
     }
   }
 
-  if (scanI2CAddress(MCP9808_I2C_ADDRESS, "MCP9808"))
+  if (scanI2CAddress(MCP9808_I2C_ADDRESS))
   {
     _mcp9808Found = _mcp9808.begin(MCP9808_I2C_ADDRESS);
     if (_mcp9808Found)
@@ -43,7 +43,7 @@ void OXRS_SENSORS::begin()
   }
 }
 
-bool OXRS_SENSORS::scanI2CAddress(byte address, const char * name)
+bool OXRS_SENSORS::scanI2CAddress(byte address)
 {
   Serial.print(F("[sens] - 0x"));
   Serial.print(address, HEX);
@@ -53,7 +53,7 @@ bool OXRS_SENSORS::scanI2CAddress(byte address, const char * name)
   Wire.beginTransmission(address);
   if (Wire.endTransmission() == 0)
   {
-    Serial.println(name);
+    Serial.println("found");
     return true;
   }
   else

--- a/src/OXRS_SENSORS.cpp
+++ b/src/OXRS_SENSORS.cpp
@@ -18,12 +18,12 @@ void OXRS_SENSORS::begin()
 {
   Serial.println(F("[sens] scanning for I2C devices..."));
 
-  if (scanI2CAddress(BH1750_I2C_ADDRESS))
+  if (scanI2CAddress(BH1750_I2C_ADDRESS, "BH1750"))
   {
     _bh1750Found = _bh1750.begin(BH1750::CONTINUOUS_HIGH_RES_MODE);
   }
 
-  if (scanI2CAddress(SHT40_I2C_ADDRESS))
+  if (scanI2CAddress(SHT40_I2C_ADDRESS, "SHT40"))
   {
     _sht40Found = _sht40.begin();
     if (_sht40Found)
@@ -33,7 +33,7 @@ void OXRS_SENSORS::begin()
     }
   }
 
-  if (scanI2CAddress(MCP9808_I2C_ADDRESS))
+  if (scanI2CAddress(MCP9808_I2C_ADDRESS, "MCP9808"))
   {
     _mcp9808Found = _mcp9808.begin(MCP9808_I2C_ADDRESS);
     if (_mcp9808Found)
@@ -43,7 +43,7 @@ void OXRS_SENSORS::begin()
   }
 }
 
-bool OXRS_SENSORS::scanI2CAddress(byte address)
+bool OXRS_SENSORS::scanI2CAddress(byte address, const char * name)
 {
   Serial.print(F("[sens] - 0x"));
   Serial.print(address, HEX);
@@ -53,7 +53,7 @@ bool OXRS_SENSORS::scanI2CAddress(byte address)
   Wire.beginTransmission(address);
   if (Wire.endTransmission() == 0)
   {
-    Serial.println("found");
+    Serial.println(name);
     return true;
   }
   else

--- a/src/OXRS_SENSORS.cpp
+++ b/src/OXRS_SENSORS.cpp
@@ -102,7 +102,11 @@ bool OXRS_SENSORS::scanI2CAddress(byte address, const char * name)
 
 void OXRS_SENSORS::tele(JsonVariant json)
 {
-  if (_updateMs > 0 && (millis() - _lastUpdate) > _updateMs)
+  // Ignore if sensor publishing has been disabled
+  if (_updateMs == 0) { return; }
+
+  // Check if we are ready to publish
+  if ((millis() - _lastUpdate) > _updateMs)
   {
     char payload[8];
 

--- a/src/OXRS_SENSORS.cpp
+++ b/src/OXRS_SENSORS.cpp
@@ -1,11 +1,9 @@
-// cpp file v0.5.0
 #include "OXRS_SENSORS.h"
 
-// OLED display - Width, height, &wire, Reset
-Adafruit_SSD1306 _ssd1306(128, 32, &Wire, -1);
-
-// PCF8523 RTC
-RTC_PCF8523 _pcf8523;
+#include <Wire.h>             // For I2C
+#include <Adafruit_MCP9808.h> // For temp sensor
+#include <BH1750.h>           // for BH1750 lux sensor
+#include <Adafruit_SHT4x.h>   // for SHT40 temp/humidity sensor
 
 // MCP9808 temp sensor
 Adafruit_MCP9808 _mcp9808 = Adafruit_MCP9808();
@@ -13,20 +11,10 @@ Adafruit_MCP9808 _mcp9808 = Adafruit_MCP9808();
 // BH1750 lux sensor
 BH1750 _bh1750;
 
-// SHT40 Temperature / Humitity Sensor
+// SHT40 temperature/humitity Sensor
 Adafruit_SHT4x _sht40 = Adafruit_SHT4x();
 
-/*
- *
- *  Main program
- *
- */
 void OXRS_SENSORS::begin()
-{
-  scanI2CBus();
-}
-
-void OXRS_SENSORS::scanI2CBus()
 {
   Serial.println(F("[sens] scanning for I2C devices..."));
 
@@ -53,31 +41,6 @@ void OXRS_SENSORS::scanI2CBus()
       _mcp9808.setResolution(MCP9808_MODE);
     }
   }
-
-  if (scanI2CAddress(SSD1306_I2C_ADDRESS, "OLED"))
-  {
-    _ssd1306Found = _ssd1306.begin(SSD1306_SWITCHCAPVCC, SSD1306_I2C_ADDRESS);
-    if (_ssd1306Found)
-    {
-      _ssd1306.clearDisplay();
-      _ssd1306.display();
-    }
-  }
-
-  if (scanI2CAddress(PCF8523_I2C_ADDRESS, "RTC"))
-  {
-    _pcf8523Found = _pcf8523.begin();
-    if (_pcf8523Found)
-    {
-      if (!_pcf8523.initialized() || _pcf8523.lostPower())
-      {
-        Serial.println(F("[sens] RTC is NOT initialized!"));
-        _pcf8523.adjust(DateTime(F(__DATE__), F(__TIME__)));
-        Serial.println(F("[sens] RTC Time set with compile time"));
-      }
-      _pcf8523.start();
-    }
-  }
 }
 
 bool OXRS_SENSORS::scanI2CAddress(byte address, const char * name)
@@ -98,6 +61,59 @@ bool OXRS_SENSORS::scanI2CAddress(byte address, const char * name)
     Serial.println(F("empty"));
     return false;
   }
+}
+
+void OXRS_SENSORS::setConfigSchema(JsonVariant json)
+{
+  JsonObject _updateSeconds = json.createNestedObject("sensorUpdateSeconds");
+  _updateSeconds["title"] = "Sensor Publish Interval (seconds)";
+  _updateSeconds["description"] = "How often to publish values from the connected I2C sensors (defaults to 60 seconds, setting to 0 disables sensor reports). Must be a number between 0 and 86400 (i.e. 1 day).";
+  _updateSeconds["type"] = "integer";
+  _updateSeconds["minimum"] = 0;
+  _updateSeconds["maximum"] = 86400;
+
+  if (_mcp9808Found || _sht40Found)
+  {
+    JsonObject _tempMode = json.createNestedObject("sensorTempMode");
+    _tempMode["type"] = "string";
+    _tempMode["description"] = "Temperature in celcius (default) or farenhite";
+    JsonArray _tempEnum = _tempMode.createNestedArray("enum");
+    _tempEnum.add("c");
+    _tempEnum.add("f");
+    JsonArray _tempEnumNames = _tempMode.createNestedArray("enumNames");
+    _tempEnumNames.add("celcius");
+    _tempEnumNames.add("farenhite");
+  }
+}
+
+void OXRS_SENSORS::setCommandSchema(JsonVariant json)
+{
+  // no commands
+}
+
+void OXRS_SENSORS::conf(JsonVariant json)
+{
+  if (json.containsKey("sensorUpdateSeconds"))
+  {
+    _updateMs = json["sensorUpdateSeconds"].as<uint32_t>() * 1000L;
+  }
+
+  if (json.containsKey("sensorTempMode"))
+  {
+    if (strcmp(json["sensorTempMode"], "c") == 0)
+    {
+      _tempMode = TEMP_C;
+    }
+    else if (strcmp(json["sensorTempMode"], "f") == 0)
+    {
+      _tempMode = TEMP_F;
+    }
+  }
+}
+
+void OXRS_SENSORS::cmnd(JsonVariant json)
+{
+  // no commands to handle
 }
 
 void OXRS_SENSORS::tele(JsonVariant json)
@@ -163,674 +179,7 @@ void OXRS_SENSORS::tele(JsonVariant json)
       json["lux"] = payload;
     }
 
-    if (_ssd1306Found)
-    {
-      char cstr2[1];
-      itoa(_sleepEnable, cstr2, 10);
-      json["oledSleepEnable"] = cstr2;
-
-      char cstr1[1];
-      itoa(_sleepState, cstr1, 10);
-      json["oledSleepState"] = cstr1;
-    }
-
     // Reset our timer
     _lastUpdate = millis();
   }
-}
-
-void OXRS_SENSORS::setConfigSchema(JsonVariant json)
-{
-  JsonObject _updateSeconds = json.createNestedObject("sensorUpdateSeconds");
-  _updateSeconds["title"] = "Sensor Update Interval (seconds)";
-  _updateSeconds["description"] = "How often to read and report the values from the connected I2C sensors  (defaults to 60 seconds, setting to 0 disables sensor reports). Must be a number between 0 and 86400 (i.e. 1 day).";
-  _updateSeconds["type"] = "integer";
-  _updateSeconds["minimum"] = 0;
-  _updateSeconds["maximum"] = 86400;
-
-  if (_mcp9808Found || _sht40Found)
-  {
-    JsonObject _tempMode = json.createNestedObject("sensorTempMode");
-    _tempMode["type"] = "string";
-    _tempMode["description"] = "Temperature reports in Farenhite or (default) Celcius";
-    JsonArray _tempEnum = _tempMode.createNestedArray("enum");
-    _tempEnum.add("c");
-    _tempEnum.add("f");
-    JsonArray _tempEnumNames = _tempMode.createNestedArray("enumNames");
-    _tempEnumNames.add("celcius");
-    _tempEnumNames.add("farenhite");
-  }
-
-  if (_pcf8523Found)
-  {
-    JsonObject _clockMode = json.createNestedObject("sensorClockMode");
-    _clockMode["type"] = "string";
-    _clockMode["description"] = "Sets OLED clock display to 12 hour or (default) 24 hour display";
-    JsonArray _clockEnum = _clockMode.createNestedArray("enum");
-    _clockEnum.add("12");
-    _clockEnum.add("24");
-  }
-
-  if (_ssd1306Found)
-  {
-    JsonObject _screenMode = json.createNestedObject("sensorScreenMode");
-    _screenMode["type"] = "string";
-    _screenMode["description"] = "Select the active / visible OLED screen on boot. Options are availble based on sensors connected but in total 5 screens + off are availble";
-    JsonArray _screenEnum = _screenMode.createNestedArray("enum");
-    _screenEnum.add("off");
-    _screenEnum.add("one");
-    if (!_pcf8523Found && _mcp9808Found && !_sht40Found)
-    {
-    }
-    else
-    {
-      _screenEnum.add("two");
-    }
-    if (!_bh1750Found && !_mcp9808Found && !_sht40Found)
-    {
-    }
-    else
-    {
-      _screenEnum.add("three");
-    }
-    if (_sht40Found)
-    {
-      _screenEnum.add("four");
-    }
-    _screenEnum.add("five");
-    JsonArray _screenEnumNames = _screenMode.createNestedArray("enumNames");
-    _screenEnumNames.add("off");
-    _screenEnumNames.add("IP Address & MAC Address");
-    if (!_pcf8523Found && _mcp9808Found && !_sht40Found)
-    {
-    }
-    else
-    {
-      _screenEnumNames.add("Time & Temperature");
-    }
-    if (!_bh1750Found && !_mcp9808Found && !_sht40Found)
-    {
-    }
-    else
-    {
-      _screenEnumNames.add("LUX & Temperature");
-    }
-    if (_sht40Found)
-    {
-      _screenEnumNames.add("Humidity & Temperature");
-    }
-    _screenEnumNames.add("2 Lines of Custom Text");
-
-    if (_ssd1306Found)
-    {
-      JsonObject _sleepOledenable = json.createNestedObject("sensorSleepOLEDEnable");
-      _sleepOledenable["type"] = "boolean";
-      _sleepOledenable["description"] = "Allows the screen to be put in sleep mode";
-    }
-  }
-}
-
-void OXRS_SENSORS::setCommandSchema(JsonVariant json)
-{
-  if (_pcf8523Found)
-  {
-    JsonObject _rtcItems = json.createNestedObject("sensorRTC");
-    _rtcItems["type"] = "array";
-    _rtcItems["description"] = "Ability to update the RTC time - year,month,day,hour,minute,seconds";
-
-    JsonObject _rtcItems2 = _rtcItems.createNestedObject("items");
-    _rtcItems2["type"] = "object";
-
-    JsonObject _rtcProperties = _rtcItems2.createNestedObject("properties");
-
-    JsonObject _rtcYear = _rtcProperties.createNestedObject("year");
-    _rtcYear["type"] = "string";
-
-    JsonObject _rtcMonth = _rtcProperties.createNestedObject("month");
-    _rtcMonth["type"] = "string";
-
-    JsonObject _rtcDay = _rtcProperties.createNestedObject("day");
-    _rtcDay["type"] = "string";
-
-    JsonObject _rtcHour = _rtcProperties.createNestedObject("hour");
-    _rtcHour["type"] = "string";
-    _rtcHour["description"] = "Requires 24 Hour Format";
-
-    JsonObject _rtcMinute = _rtcProperties.createNestedObject("minute");
-    _rtcMinute["type"] = "string";
-
-    JsonObject _rtcSeconds = _rtcProperties.createNestedObject("seconds");
-    _rtcSeconds["type"] = "string";
-
-    JsonArray _required = _rtcItems2.createNestedArray("required");
-    _required.add("year");
-    _required.add("month");
-    _required.add("day");
-    _required.add("hour");
-    _required.add("minute");
-    _required.add("seconds");
-  }
-
-  if (_ssd1306Found)
-  {
-    JsonObject _screenMode = json.createNestedObject("sensorScreenMode");
-    _screenMode["type"] = "string";
-    _screenMode["description"] = "Select the active / visible OLED screen. Options are availble based on sensors connected but in total 5 screens + off are availble";
-    JsonArray _screenEnum = _screenMode.createNestedArray("enum");
-    _screenEnum.add("off");
-    _screenEnum.add("one");
-    if (!_pcf8523Found && _mcp9808Found && !_sht40Found)
-    {
-    }
-    else
-    {
-      _screenEnum.add("two");
-    }
-    if (!_bh1750Found && !_mcp9808Found && !_sht40Found)
-    {
-    }
-    else
-    {
-      _screenEnum.add("three");
-    }
-    if (_sht40Found)
-    {
-      _screenEnum.add("four");
-    }
-    _screenEnum.add("five");
-    JsonArray _screenEnumNames = _screenMode.createNestedArray("enumNames");
-    _screenEnumNames.add("off");
-    _screenEnumNames.add("IP Address & MAC Address");
-    if (!_pcf8523Found && _mcp9808Found && !_sht40Found)
-    {
-    }
-    else
-    {
-      _screenEnumNames.add("Time & Temperature");
-    }
-    if (!_bh1750Found && !_mcp9808Found && !_sht40Found)
-    {
-    }
-    else
-    {
-      _screenEnumNames.add("LUX & Temperature");
-    }
-    if (_sht40Found)
-    {
-      _screenEnumNames.add("Humidity & Temperature");
-    }
-    _screenEnumNames.add("2 Lines of Custom Text");
-
-    JsonObject _oneOLED = json.createNestedObject("sensorOneOLED");
-    _oneOLED["type"] = "string";
-    _oneOLED["description"] = "Show custom text on OLED line 1 - max 10 characters";
-    _oneOLED["maxLength"] = 10;
-
-    JsonObject _twoOLED = json.createNestedObject("sensorTwoOLED");
-    _twoOLED["type"] = "string";
-    _twoOLED["description"] = "Show custom text on OLED line 2 - max 10 characters";
-    _twoOLED["maxLength"] = 10;
-
-    JsonObject _sleeping = json.createNestedObject("sensorSleepOLED");
-    _sleeping["type"] = "boolean";
-    _sleeping["description"] = "Puts the screen into a sleep state - unlike off, data / information can still be pushed to teh display but won't be visible until sleep is turned off";
-  }
-}
-
-void OXRS_SENSORS::conf(JsonVariant json)
-{
-  if (json.containsKey("sensorUpdateSeconds"))
-  {
-    _updateMs = json["sensorUpdateSeconds"].as<uint32_t>() * 1000L;
-  }
-
-  if (json.containsKey("sensorScreenMode")) // for what mode the OLED is in
-  {
-    if (strcmp(json["sensorScreenMode"], "off") == 0)
-    {
-      _screenMode = OLED_MODE_OFF;
-    }
-    if (strcmp(json["sensorScreenMode"], "one") == 0)
-    {
-      _screenMode = OLED_MODE_ONE;
-    }
-    if (strcmp(json["sensorScreenMode"], "two") == 0)
-    {
-      _screenMode = OLED_MODE_TWO;
-    }
-    if (strcmp(json["sensorScreenMode"], "three") == 0)
-    {
-      _screenMode = OLED_MODE_THREE;
-    }
-    if (strcmp(json["sensorScreenMode"], "four") == 0)
-    {
-      _screenMode = OLED_MODE_FOUR;
-    }
-    if (strcmp(json["sensorScreenMode"], "five") == 0)
-    {
-      _screenMode = OLED_MODE_FIVE;
-    }
-  }
-
-  if (json.containsKey("sensorClockMode"))
-  {
-    if (strcmp(json["sensorClockMode"], "12") == 0)
-    {
-      _clockMode = PCF8523_12;
-    }
-    else if (strcmp(json["sensorClockMode"], "24") == 0)
-    {
-      _clockMode = PCF8523_24;
-    }
-  }
-
-  if (json.containsKey("sensorTempMode"))
-  {
-    if (strcmp(json["sensorTempMode"], "c") == 0)
-    {
-      _tempMode = TEMP_C;
-    }
-    else if (strcmp(json["sensorTempMode"], "f") == 0)
-    {
-      _tempMode = TEMP_F;
-    }
-  }
-
-  if (json.containsKey("sensorSleepOLEDEnable"))
-  {
-    _sleepEnable = json["sensorSleepOLEDEnable"].as<bool>() ? HIGH : LOW;
-  }
-}
-
-void OXRS_SENSORS::cmnd(JsonVariant json)
-{
-  if (json.containsKey("sensorRTC"))
-  {
-    for (JsonVariant RTC : json["sensorRTC"].as<JsonArray>())
-    {
-      jsonRtcCommand(RTC);
-    }
-  }
-
-  if (json.containsKey("sensorScreenMode")) // for what mode the OLED is in
-  {
-    if (strcmp(json["sensorScreenMode"], "off") == 0)
-    {
-      _screenMode = OLED_MODE_OFF;
-    }
-    if (strcmp(json["sensorScreenMode"], "one") == 0)
-    {
-      _screenMode = OLED_MODE_ONE;
-    }
-    if (strcmp(json["sensorScreenMode"], "two") == 0)
-    {
-      _screenMode = OLED_MODE_TWO;
-    }
-    if (strcmp(json["sensorScreenMode"], "three") == 0)
-    {
-      _screenMode = OLED_MODE_THREE;
-    }
-    if (strcmp(json["sensorScreenMode"], "four") == 0)
-    {
-      _screenMode = OLED_MODE_FOUR;
-    }
-    if (strcmp(json["sensorScreenMode"], "five") == 0)
-    {
-      _screenMode = OLED_MODE_FIVE;
-    }
-  }
-
-  if (json.containsKey("sensorOneOLED")) // custom text for OLED
-  {
-    _screenLineOne = json["sensorOneOLED"].as<String>();
-  }
-
-  if (json.containsKey("sensorTwoOLED")) // custom text for OLED
-  {
-    _screenLineTwo = json["sensorTwoOLED"].as<String>();
-  }
-
-  if (json.containsKey("sensorSleepOLED"))
-  {
-    if (_sleepEnable)
-    {
-      _sleepState = json["sensorSleepOLED"].as<bool>() ? HIGH : LOW;
-    }
-  }
-}
-
-void OXRS_SENSORS::jsonRtcCommand(JsonVariant json)
-{
-  // TODO: you can use RegEx in your JSON command schema to validate a string
-  //       to ensure it is a known date/time format - this might be easier?
-
-  if (json.containsKey("year")) // set RTC time
-  {
-    if (!json.containsKey("month"))
-    {
-      return;
-    }
-    if (!json.containsKey("day"))
-    {
-      return;
-    }
-    if (!json.containsKey("hour"))
-    {
-      return;
-    }
-    if (!json.containsKey("minute"))
-    {
-      return;
-    }
-    if (!json.containsKey("seconds"))
-    {
-      return;
-    }
-    //      January 21, 2014 at 3am you would call:
-    //      rtc.adjust(DateTime(2014, 1, 21, 3, 0, 0));
-    _pcf8523.adjust(DateTime(json["year"].as<uint16_t>(), json["month"].as<uint8_t>(), json["day"].as<uint8_t>(), json["hour"].as<uint8_t>(), json["minute"].as<uint8_t>(), json["seconds"].as<uint8_t>()));
-  }
-}
-
-/*
- *
- * OLED code
- *
- */
-
-// single line limit with font 2 is 10 charactors
-
-void OXRS_SENSORS::off_screen() // custom text on line one
-{
-  _ssd1306.clearDisplay();
-  _ssd1306.display();
-}
-
-void OXRS_SENSORS::one_screen() // custom text on line one
-{
-  _ssd1306.setCursor(0, 0);
-  _ssd1306.print(_screenLineOne);
-}
-
-void OXRS_SENSORS::two_screen() // custom text on line two
-{
-  _ssd1306.setCursor(0, 16);
-  _ssd1306.print(_screenLineTwo);
-}
-
-void OXRS_SENSORS::time_screen() // show time on line one
-{
-  if (_pcf8523Found) // show the time if time is availble
-  {
-    _ssd1306.setCursor(0, 0);
-    if (_clockMode == PCF8523_12) // 12 hour clock requested
-    {
-      if (_currentHour >= 13)
-      {
-        _modHour = _currentHour - 12;
-        if (_modHour < 10)
-        {
-          _ssd1306.print(" ");
-        }
-        _ssd1306.print(_modHour);
-      }
-      else if (_currentHour == 0)
-      {
-        _ssd1306.print("12");
-      }
-      else
-      {
-        if (_currentHour < 10)
-        {
-          _ssd1306.print(" ");
-        }
-        _ssd1306.print(_currentHour);
-      }
-
-      _ssd1306.print(":");
-      if (_currentMinute < 10)
-      {
-        _ssd1306.print("0");
-      }
-      _ssd1306.print(_currentMinute);
-
-      if (_currentHour >= 13)
-      {
-        _ssd1306.print(" PM");
-      }
-      else
-      {
-        _ssd1306.print(" AM");
-      }
-    }
-
-    if (_clockMode == PCF8523_24) // 24 hour clock requested
-    {
-      if (_currentHour < 10)
-      {
-        _ssd1306.print('0');
-      }
-      _ssd1306.print(_currentHour);
-      _ssd1306.print(":");
-      if (_currentMinute < 10)
-      {
-        _ssd1306.print('0');
-      }
-      _ssd1306.print(_currentMinute);
-      _ssd1306.print("h");
-    }
-  }
-}
-
-void OXRS_SENSORS::temp_screen() // line two showing temp
-{
-  if (_sht40Found)
-  {
-    _ssd1306.setCursor(0, 16); // line 2
-    if (_tempMode == TEMP_C)
-    {
-      _ssd1306.print(_c, 1);
-      _ssd1306.print("\tC");
-    }
-    if (_tempMode == TEMP_F)
-    {
-      _ssd1306.print(_f, 1);
-      _ssd1306.print("\tF");
-    }
-  }
-  else if (_mcp9808Found)
-  {
-    _ssd1306.setCursor(0, 16); // line 2
-    if (_tempMode == TEMP_C)
-    {
-      _ssd1306.print(_c, 1);
-      _ssd1306.print("\tC");
-    }
-    if (_tempMode == TEMP_F)
-    {
-      _ssd1306.print(_f, 1);
-      _ssd1306.print("\tF");
-    }
-  }
-}
-
-void OXRS_SENSORS::hum_screen()
-{
-  if (_sht40Found)
-  {
-    _ssd1306.setCursor(0, 0); // line 1
-    _ssd1306.print(_h, 1);
-    _ssd1306.print("% rH");
-  }
-}
-
-void OXRS_SENSORS::lux_screen() // line one showing lux
-{
-  if (_bh1750Found)
-  {
-    _ssd1306.setCursor(0, 0); // line 1
-    _ssd1306.print(_l, 1);
-    _ssd1306.print(" LUX");
-  }
-}
-
-void OXRS_SENSORS::IP_screen() // line one showing IP address
-{
-  _ssd1306.setTextSize(1);
-  _ssd1306.setCursor(0, 0); // line 1
-  _ssd1306.print(_ipAddress);
-}
-
-void OXRS_SENSORS::MAC_screen() // line two showing mac address
-{
-  _ssd1306.setTextSize(1);
-  char mac_display[18];
-  sprintf_P(mac_display, PSTR("%02X:%02X:%02X:%02X:%02X:%02X"), _mac[0], _mac[1], _mac[2], _mac[3], _mac[4], _mac[5]);
-  _ssd1306.setCursor(0, 16); // line 2
-  _ssd1306.print(mac_display);
-}
-
-void OXRS_SENSORS::oled() // control the OLED screen if availble
-{
-  if (_ssd1306Found)
-  {
-    oledUpdate();
-  }
-}
-
-void OXRS_SENSORS::oled(byte *mac) // control the OLED screen if availble
-{
-  memcpy(_mac, mac, 6);
-
-  if (_ssd1306Found)
-  {
-    oledUpdate();
-  }
-}
-
-void OXRS_SENSORS::oled(IPAddress ip) // control the OLED screen if availble
-{
-  _ipAddress = ip;
-  if (_ssd1306Found)
-  {
-    oledUpdate();
-  }
-}
-
-void OXRS_SENSORS::oledUpdate() // control the OLED screen if availble
-{
-  if ((millis() - _previousOledtemp) > OLED_INTERVAL_TEMP)
-  {
-    // MCP9808 temp sensor has precedence over SHT40
-    if (_mcp9808Found)
-    {
-      _c = _mcp9808.readTempC();
-      _f = _mcp9808.readTempF();
-    }
-
-    if (_sht40Found)
-    {
-      sensors_event_t humid, temp;
-      _sht40.getEvent(&humid, &temp);
-
-      if (!_mcp9808Found)
-      {
-        _c = temp.temperature;
-        _f = (temp.temperature * 1.8) + 32;
-      }
-
-      _h = humid.relative_humidity;
-    }
-
-    // Reset our timer
-    _previousOledtemp = millis();
-  }
-
-  if ((millis() - _previousOledlux) > OLED_INTERVAL_LUX)
-  {
-    if (_bh1750Found && _bh1750.measurementReady())
-    {
-      _l = _bh1750.readLightLevel();
-      _previousOledlux = millis();
-    }
-  }
-
-  if (_pcf8523Found)
-  {
-    // Time Keeping
-    DateTime now = _pcf8523.now();
-    _currentHour = now.hour();
-    _currentMinute = now.minute();
-  }
-
-  if (_sleepState) // screen goes to sleep
-  {
-    off_screen();
-  }
-  else
-  {
-    _ssd1306.clearDisplay();
-    _ssd1306.setTextSize(2);
-    _ssd1306.setTextColor(WHITE);
-
-    if (_screenMode == OLED_MODE_OFF)
-    {
-      off_screen();
-    }
-    if (_screenMode == OLED_MODE_ONE)
-    {
-      IP_screen();
-      MAC_screen();
-    }
-    if (_screenMode == OLED_MODE_TWO)
-    {
-      time_screen();
-      temp_screen();
-    }
-    if (_screenMode == OLED_MODE_THREE)
-    {
-      lux_screen();
-      temp_screen();
-    }
-    if (_screenMode == OLED_MODE_FOUR)
-    {
-      hum_screen();
-      temp_screen();
-    }
-    if (_screenMode == OLED_MODE_FIVE)
-    {
-      one_screen();
-      two_screen();
-    }
-
-    _ssd1306.display();
-  }
-}
-
-// getter functions to expose internal value / settings
-
-// return measured temperature in configured mode
-float OXRS_SENSORS::getTemperatureValue() 
-{
-  float temperature = NAN;
-  // MCP9808 temp sensor has precedence over SHT40
-  if (_mcp9808Found)
-  {
-    if (_tempMode == TEMP_C)
-    {
-      temperature = _mcp9808.readTempC();
-    }
-    else if (_tempMode == TEMP_F)
-    {
-      temperature = _mcp9808.readTempF();
-    }
-  }
-
-  return temperature;
-}
-
-// return setting for units
-bool OXRS_SENSORS::getTemperatureUnits()
-{
-  return _tempMode;
 }

--- a/src/OXRS_SENSORS.cpp
+++ b/src/OXRS_SENSORS.cpp
@@ -74,15 +74,15 @@ void OXRS_SENSORS::setConfigSchema(JsonVariant json)
 
   if (_mcp9808Found || _sht40Found)
   {
-    JsonObject _tempMode = json.createNestedObject("sensorTempMode");
-    _tempMode["type"] = "string";
-    _tempMode["description"] = "Temperature in celcius (default) or farenhite";
-    JsonArray _tempEnum = _tempMode.createNestedArray("enum");
-    _tempEnum.add("c");
-    _tempEnum.add("f");
-    JsonArray _tempEnumNames = _tempMode.createNestedArray("enumNames");
-    _tempEnumNames.add("celcius");
-    _tempEnumNames.add("farenhite");
+    JsonObject _tempUnits = json.createNestedObject("sensorTempUnits");
+    _tempUnits["type"] = "string";
+    _tempUnits["description"] = "Temperature reports in celcius (default) or farenhite";
+    JsonArray _tempUnitsEnum = _tempUnits.createNestedArray("enum");
+    _tempUnitsEnum.add("c");
+    _tempUnitsEnum.add("f");
+    JsonArray _tempUnitsEnumNames = _tempUnits.createNestedArray("enumNames");
+    _tempUnitsEnumNames.add("celcius");
+    _tempUnitsEnumNames.add("farenhite");
   }
 }
 
@@ -102,11 +102,11 @@ void OXRS_SENSORS::conf(JsonVariant json)
   {
     if (strcmp(json["sensorTempMode"], "c") == 0)
     {
-      _tempMode = TEMP_C;
+      _tempUnits = TEMP_C;
     }
     else if (strcmp(json["sensorTempMode"], "f") == 0)
     {
-      _tempMode = TEMP_F;
+      _tempUnits = TEMP_F;
     }
   }
 }
@@ -131,11 +131,11 @@ void OXRS_SENSORS::tele(JsonVariant json)
     {
       float temperature = NAN;
 
-      if (_tempMode == TEMP_C)
+      if (_tempUnits == TEMP_C)
       {
         temperature = _mcp9808.readTempC();
       }
-      else if (_tempMode == TEMP_F)
+      else if (_tempUnits == TEMP_F)
       {
         temperature = _mcp9808.readTempF();
       }
@@ -157,7 +157,7 @@ void OXRS_SENSORS::tele(JsonVariant json)
       {
         // sensor reading is in C, so check if we need to convert to F
         float temperature = temp.temperature;
-        if (_tempMode == TEMP_F)
+        if (_tempUnits == TEMP_F)
         {
           temperature = (temperature * 1.8) + 32;
         }

--- a/src/OXRS_SENSORS.h
+++ b/src/OXRS_SENSORS.h
@@ -43,7 +43,7 @@ private:
   bool _bh1750Found = false;
   bool _sht40Found = false;
 
-  bool scanI2CAddress(byte address, const char * name);
+  bool scanI2CAddress(byte address);
 };
 
 #endif

--- a/src/OXRS_SENSORS.h
+++ b/src/OXRS_SENSORS.h
@@ -117,7 +117,7 @@ private:
   void jsonRtcCommand(JsonVariant json);
 
   void scanI2CBus();
-  bool scanI2CAddress(byte address);
+  bool scanI2CAddress(byte address, const char * name);
 
   void off_screen();
   void one_screen();

--- a/src/OXRS_SENSORS.h
+++ b/src/OXRS_SENSORS.h
@@ -43,7 +43,7 @@ private:
   bool _bh1750Found = false;
   bool _sht40Found = false;
 
-  bool scanI2CAddress(byte address);
+  bool scanI2CAddress(byte address, const char * name);
 };
 
 #endif

--- a/src/OXRS_SENSORS.h
+++ b/src/OXRS_SENSORS.h
@@ -1,28 +1,12 @@
-// h file v0.5.0
-
 #ifndef OXRS_SENSORS_H
 #define OXRS_SENSORS_H
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
-#include <Wire.h>             // For I2C
-#include <Adafruit_MCP9808.h> // For temp sensor
-#include <Adafruit_SSD1306.h> // for OLED display
-#include <RTClib.h>           // for PCF8523 RTC
-#include <BH1750.h>           // for BH1750 lux sensor
-#include <Adafruit_SHT4x.h>   // for SHT40 Temp / humidity sensor
-
-#if defined(ESP8266)
-#include <ESP8266WiFi.h>
-#else
-#include <WiFi.h>
-#endif
 
 #define DEFAULT_UPDATE_MS 60000
 
-#define DEFAULT_OLED_SLEEP_ENABLE true
-
-// general temp monitoring varible
+// Temperature units
 #define TEMP_C 0
 #define TEMP_F 1
 
@@ -36,99 +20,30 @@
 // BH1750 LUX sensor
 #define BH1750_I2C_ADDRESS 0x23 // or 0x5C
 
-// PCF8523 RTC Module
-#define PCF8523_I2C_ADDRESS 0x68
-#define PCF8523_12 0
-#define PCF8523_24 1
-
-// OLED Screen
-#define SSD1306_I2C_ADDRESS 0x3C
-#define OLED_INTERVAL_TEMP 10000L
-#define OLED_INTERVAL_LUX 2500L
-
-// Supported OLED modes
-#define OLED_MODE_OFF 0   // screen is off
-#define OLED_MODE_ONE 1   // screen shows IP and MAC address
-#define OLED_MODE_TWO 2   // screen shows Time and Temp
-#define OLED_MODE_THREE 3 // screen shows Temp and LUX
-#define OLED_MODE_FOUR 4  // screen shows Temp and Humidity
-#define OLED_MODE_FIVE 5  // screen shows Custom text per - line
-
 class OXRS_SENSORS
 {
 public:
   void begin();
 
-  void oled();
-  void oled(IPAddress ip);
-  void oled(byte * mac);
-
-  void tele(JsonVariant json);
+  void setConfigSchema(JsonVariant json);
+  void setCommandSchema(JsonVariant json);
 
   void conf(JsonVariant json);
   void cmnd(JsonVariant json);
 
-  void setConfigSchema(JsonVariant json);
-  void setCommandSchema(JsonVariant json);
-
-  float getTemperatureValue(void);
-  bool  getTemperatureUnits(void);
+  void tele(JsonVariant json);
 
 private:
-
-  IPAddress _ipAddress;
-
-  byte _mac[6];
-
   uint32_t _updateMs = DEFAULT_UPDATE_MS;
   uint32_t _lastUpdate;
+  uint8_t  _tempUnits = TEMP_C;
 
-  // i2c scan results
-  bool _bh1750Found = false;
+  // I2C scan results
   bool _mcp9808Found = false;
+  bool _bh1750Found = false;
   bool _sht40Found = false;
-  bool _ssd1306Found = false;
-  bool _pcf8523Found = false;
 
-  // OLED varibles
-  uint8_t _screenMode = OLED_MODE_ONE;
-  uint8_t _sleepEnable = DEFAULT_OLED_SLEEP_ENABLE;
-  uint8_t _sleepState = !_sleepEnable;
-  String _screenLineOne = "Hello";
-  String _screenLineTwo = "World";
-
-  // universal tmperature variable - for degrees c / f
-  bool _tempMode = TEMP_C;
-
-  // sensor varibles - using with OLED
-  float _c; // temp reading variable
-  float _f; // temp reading variable
-  float _h; // hum  reading variable sht40
-  float _l; // lux reading variable
-  unsigned long _previousOledtemp = 0;
-  unsigned long _previousOledlux = 0;
-
-  // RTC varibles
-  uint8_t _modHour;
-  int _currentHour;
-  int _currentMinute;
-  uint8_t _clockMode = PCF8523_24;
-
-  void jsonRtcCommand(JsonVariant json);
-
-  void scanI2CBus();
   bool scanI2CAddress(byte address, const char * name);
-
-  void off_screen();
-  void one_screen();
-  void two_screen();
-  void time_screen();
-  void temp_screen();
-  void hum_screen();
-  void lux_screen();
-  void IP_screen();
-  void MAC_screen();
-  void oledUpdate();
 };
 
 #endif

--- a/src/OXRS_SENSORS.h
+++ b/src/OXRS_SENSORS.h
@@ -4,7 +4,6 @@
 #define OXRS_SENSORS_H
 
 #include <Arduino.h>
-#include <OXRS_MQTT.h>
 #include <ArduinoJson.h>
 #include <Wire.h>             // For I2C
 #include <Adafruit_MCP9808.h> // For temp sensor
@@ -58,15 +57,13 @@
 class OXRS_SENSORS
 {
 public:
-  OXRS_SENSORS(OXRS_MQTT &mqtt);
-
   void begin();
 
   void oled();
   void oled(IPAddress ip);
   void oled(byte * mac);
 
-  void tele();
+  void tele(JsonVariant json);
 
   void conf(JsonVariant json);
   void cmnd(JsonVariant json);
@@ -82,8 +79,6 @@ private:
   IPAddress _ipAddress;
 
   byte _mac[6];
-
-  OXRS_MQTT *_sensorMqtt;
 
   uint32_t _updateMs = DEFAULT_UPDATE_MS;
   uint32_t _lastUpdate;
@@ -122,6 +117,7 @@ private:
   void jsonRtcCommand(JsonVariant json);
 
   void scanI2CBus();
+  bool scanI2CAddress(byte address);
 
   void off_screen();
   void one_screen();


### PR DESCRIPTION
Remove OXRS_MQTT dependency, since with our new OXRS platform libs (e.g. OXRS_RACK32 and OXRS_LILYGO) we don't have access to the MQTT client directly.

Also tidied up the I2C scanning code to reduce duplication a bit.

Haven't tested yet, but will do so tomorrow. 